### PR TITLE
Set Go version using go toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/spegel-org/benchmark
 
-go 1.24.2
+go 1.24.0
+
+toolchain go1.24.3
 
 require (
 	github.com/alexflint/go-arg v1.5.1


### PR DESCRIPTION
This change allows us to set the Go version used to build without requiring a specific Go version to import the project.